### PR TITLE
reduce data pull for water features with bounding box

### DIFF
--- a/17-islands/17-disappearing-chesapeake.R
+++ b/17-islands/17-disappearing-chesapeake.R
@@ -8,7 +8,7 @@ bay_states <- states(cb = TRUE) %>%
   filter(name %in% c("Virginia", "Delaware", "Maryland", "District of Columbia")) %>%
   st_transform(26917)
 
-# cheapeake shoreline over time from https://data.imap.maryland.gov/datasets/maryland-shoreline-changes-legacy-historic-shorelines-by-years?geometry=-83.697%2C36.846%2C-71.370%2C39.861
+# Chesapeake shoreline over time from https://data.imap.maryland.gov/datasets/maryland-shoreline-changes-legacy-historic-shorelines-by-years?geometry=-83.697%2C36.846%2C-71.370%2C39.861
 shoreline <- read_sf("https://opendata.arcgis.com/datasets/b7dec3418668473c82002ee28e280eae_3.geojson") %>%
   janitor::clean_names() %>%
   st_transform(26917)
@@ -21,8 +21,9 @@ land <- bay_states %>%
 hazard <- read_sf("https://opendata.arcgis.com/datasets/35a3cce465634531a43d6d01988a43cf_1.geojson") %>%
   st_transform(26917)
 
-# all USA water bodies-- very large file!
-water <- read_sf("https://opendata.arcgis.com/datasets/48c77cbde9a0470fb371f8c8a8a7421a_0.geojson") %>%
+# all USA water bodies - very large file!
+# https://hub.arcgis.com/datasets/esri::usa-detailed-water-bodies
+water <- read_sf("https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Detailed_Water_Bodies/FeatureServer/0/query?where=1%3D1&outFields=*&geometry=-89.409%2C34.653%2C-62.229%2C40.732&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelIntersects&outSR=4326&f=json") %>%
   st_transform(26917)
 
 chesapeake_water <- water %>%
@@ -44,7 +45,7 @@ ggplot(land) +
   geom_sf(data = hazard %>% filter(Hazard_with_Habitats %in% c("Moderate", "High")),  aes(color = Hazard_with_Habitats), size = 0.08, show.legend = FALSE) +
   scale_color_manual(values = c("Moderate" = colorspace::lighten("#F3AE79"), "High" = ("#CD4D46"))) +
   theme_void() +
-  # artifically add water background
+  # artificially add water background
   theme(panel.background = element_rect(fill = "#D7E9EE"))
 
 ggsave("17-islands/chesapeake_islands.png", width = 6, height = 7, dpi = 300)


### PR DESCRIPTION
I saw this map on Twitter and it really caught my eye, nice work. This PR is just a few cosmetic editing suggestions, and a way to reduce the request size for the water layer.

P.S., the upper-left description paragraph in the .png has a typo for "Chespaeake" instead of "Chesapeake".